### PR TITLE
Feature/GitHub issue create skill

### DIFF
--- a/.github/ISSUE_TEMPLATE/pipeline-general-template.md
+++ b/.github/ISSUE_TEMPLATE/pipeline-general-template.md
@@ -1,0 +1,31 @@
+## User Story
+
+**AS A** type of user
+
+**I WANT** some goal
+
+**SO THAT** some reason
+
+## Acceptance Criteria
+1. 
+
+## Notes
+1. 
+
+## Tasks
+- [ ] ...
+- [ ] Clean up any AWS resources created during backlog work
+- [ ] DOD [Link to checklist](https://www.notion.so/imos-world/Definition-of-Done-DoD-b98281f003a44ce890dfba5af2f00337)
+
+
+## PRs
+[Pull Request (PR) Review Guidelines](https://www.notion.so/imos-world/Pull-Request-PR-Review-Guidelines-f726880c6f1542c9a9ef906f8397a5fa)
+
+1.
+
+
+## Dependencies
+1.
+
+## Demo
+1.

--- a/.github/instructions/wis2box-aodn.instructions.md
+++ b/.github/instructions/wis2box-aodn.instructions.md
@@ -1,0 +1,105 @@
+---
+applyTo: "wis2-pipeline/wis2box-data/**/*.yml,wis2-pipeline/wis2box-data/**/*.yaml,wis2-pipeline/wis2box-data/**/*.csv,wis2-pipeline/wis2box-data/**/*.json,wis2-pipeline/wis2box-data/**/*.sh"
+---
+
+# wis2box-aodn Data Pipeline Conventions
+
+This repository manages WIS 2.0 data publishing for AODN using [wis2box](https://docs.wis2box.wis.wmo.int/). The pipeline has three main artefact types — discovery metadata (MCF YAML), station metadata (CSV), and BUFR mapping templates (JSON). Keep them consistent with each other and with the station inventory.
+
+## Discovery Metadata (`metadata/discovery/*.yml`)
+
+Each `.yml` file is a WMO MCF (Metadata Control File) that registers a dataset collection in the WIS 2.0 global catalogue.
+
+### Required top-level blocks
+
+| Block | Purpose |
+|---|---|
+| `wis2box:` | wis2box runtime config — retention, topic hierarchy, data mappings |
+| `mcf:` | MCF spec version (`1.0`) |
+| `metadata:` | `identifier` and `hierarchylevel` |
+| `identification:` | Title, abstract, keywords, extents, data policy |
+| `contact:` | Host organisation contact details |
+
+### When to update
+
+| Change | Field(s) to update |
+|---|---|
+| New dataset or collection | Create a new `.yml`; set `metadata.identifier` to `urn:wmo:md:au-imos:<dataset-name>` |
+| Topic hierarchy change | `wis2box.topic_hierarchy` and `publish_metadata.sh` `-th` argument |
+| Temporal extent change | `identification.extents.temporal.begin` / `end` / `resolution` |
+| Spatial coverage change | `identification.extents.spatial[].bbox` |
+| Data retention policy change | `wis2box.retention` (ISO 8601 duration, e.g. `P30D`) |
+| CSV-to-BUFR template change | `wis2box.data_mappings.plugins.csv[].template` |
+| Data policy change | `identification.wmo_data_policy` (`core` or `recommended`) |
+
+### Conventions
+
+- `metadata.identifier` format: `urn:wmo:md:au-imos:<dataset-name>` (lowercase, hyphenated)
+- `wis2box.topic_hierarchy` format: `au-imos/data/core/<domain>/<subdomain>/<dataset-name>`
+- `wis2box.centre_id` is always `au-imos`
+- `wis2box.country` is always `AUS`
+- Dates use `YYYY-MM-DD`; `end: null` means ongoing
+
+## Station Metadata (`metadata/station/*.csv`)
+
+Station CSV files are loaded into wis2box via `wis2box metadata station publish-collection`.
+
+### Required columns
+
+| Column | Format / Example |
+|---|---|
+| `station_name` | Uppercase hyphenated, e.g. `APOLLO-BAY` |
+| `wigos_station_identifier` | `0-<issuer>-0-<id>`, e.g. `0-22000-0-7811080` |
+| `traditional_station_identifier` | Numeric string, e.g. `7811080` |
+| `facility_type` | `seaFixed` for fixed ocean buoys |
+| `latitude` / `longitude` | Decimal degrees (negative south/west) |
+| `elevation` / `barometer_height` | Metres above sea level; use `0` if not applicable |
+| `territory_name` | `AUS` |
+| `wmo_region` | `southWestPacific` for Australian stations |
+
+### When to update
+
+| Change | Action |
+|---|---|
+| New station added | Append a row to `station_list.csv`; run `publish_metadata.sh` to push to wis2box |
+| Station decommissioned | Remove or comment out the row; re-publish |
+| Coordinates corrected | Update `latitude` / `longitude` in place |
+| WIGOS ID assigned or corrected | Update `wigos_station_identifier` and `traditional_station_identifier` |
+
+## BUFR Mapping Templates (`mappings/*.json`)
+
+Templates follow the [csv2bufr](https://csv2bufr.readthedocs.io/) `csv2bufr-template-v2.json` schema and define how CSV observation columns map to BUFR parameters.
+
+### When to update
+
+| Change | Field(s) to update |
+|---|---|
+| New CSV input column mapped | Add entry to `data[]` array with correct `eccodes_key` and `valid_min`/`valid_max` |
+| CSV delimiter or quoting change | `delimiter`, `quoting`, `quotechar` at top level |
+| WIGOS station identifier source column changes | `wigos_station_identifier` key |
+| BUFR edition or category change | `header[]` entries (`edition`, `dataCategory`, `internationalDataSubCategory`) |
+| Template version bump | `metadata.version` and `metadata.dateModified` |
+
+### Conventions
+
+- `metadata.id` is a UUID — generate a new one only when creating a brand-new template
+- Valid range constraints (`valid_min`, `valid_max`) must align with WMO BUFR table definitions
+- Do **not** duplicate the `_prototype` file; it exists as a reference only
+
+## Scripts (`scripts/`)
+
+`publish_metadata.sh` and `unpublish_metadata.sh` run inside the `wis2box-management` Docker container via `docker exec`.
+
+### When to update
+
+| Change | Script section to update |
+|---|---|
+| New topic hierarchy for station publish | `-th` flag in the `wis2box metadata station publish-collection` call |
+| New discovery metadata file added | No change needed — the script auto-discovers all `*.yml` files |
+| Container or cluster name change | Update the inline AWS ECS command in the manual-alternative comment block |
+
+### Conventions
+
+- Always `set -e` at the top; never suppress errors silently
+- Use the existing `print_status` / `print_success` / `print_error` helpers for output — do not use bare `echo`
+- `wis2box` CLI commands must reference paths inside the container (`/data/wis2box/…`), not host paths

--- a/.github/skills/create-gh-issue/SKILL.md
+++ b/.github/skills/create-gh-issue/SKILL.md
@@ -1,3 +1,14 @@
+---
+name: create-gh-issue
+description: >
+  Use when creating, filing, or logging a GitHub issue in aodn/backlog.
+  Handles user stories, feature requests, enhancements, tasks, bugs, epics,
+  and technical debt items. Automatically formats the title with the correct
+  prefix and T-level tags, populates every section of the AODN body template,
+  applies appropriate labels, and adds the new issue to the AODN Pipeline
+  Uplift Team project board (#72).
+---
+
 # Create Issue
 
 Create a GitHub issue for the AODN Pipeline Uplift Team project following the appropriate template.

--- a/.github/skills/create-gh-issue/SKILL.md
+++ b/.github/skills/create-gh-issue/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when creating, filing, or logging a GitHub issue in aodn/backlog.
   Handles user stories, feature requests, enhancements, tasks, bugs, epics,
   and technical debt items. Automatically formats the title with the correct
-  prefix and T-level tags, populates every section of the AODN body template,
+  prefix and type tags, populates every section of the AODN body template,
   applies appropriate labels, and adds the new issue to the AODN Pipeline
   Uplift Team project board (#72).
 ---
@@ -41,17 +41,16 @@ When the user describes an issue, determine the type, format the title correctly
 Titles follow this structure:
 
 ```
-<prefix> <Short description> <[T-level tags]> <[type tag]>
+<prefix> <Short description> <[type tag]>
 ```
 
-- **T-level tags** categorise the work area, e.g. `[T3 - ARDC Waves]`, `[T3 - Reef Network]`, `[T1 - IMOS, T2 - O&M - Continuous Improvement]`
 - **Type tags**: `[epic]`, `[bug]`, `[technical debt]`, `[DEVOPS, general backlog]`
 - Story points are set via **labels only** (not in the title)
 
 ### Examples
 
 ```
-AS A wave data user I WANT NRT buoy data gaps filled SO THAT my analysis is complete [T3 - ARDC Waves]
+AS A wave data user I WANT NRT buoy data gaps filled SO THAT my analysis is complete
 ✨WIS2.0 Prefect Flow
 📋(TASK) Apply mask into GSLA particle PNG generation
 Test implementation of WIS2.0 Wave Buoys Collection [epic]

--- a/.github/skills/create-gh-issue/create-issue.md
+++ b/.github/skills/create-gh-issue/create-issue.md
@@ -1,0 +1,93 @@
+# Create Issue
+
+Create a GitHub issue for the project following the appropriate template.
+
+## Instructions
+
+When the user describes an issue, determine the appropriate template and create a properly formatted issue file:
+
+### Template Selection
+
+create an common template under `.github/ISSUE_TEMPLATE/`
+
+### Workflow
+
+1. Read the appropriate template from `.github/ISSUE_TEMPLATE/`
+2. Create the issue content following the template structure:
+   - Use proper user story format: AS A/I WANT/SO THAT
+   - Include acceptance criteria as checklist
+   - Add relevant sections (sub-tasks, related tickets, etc.)
+3. Write the content to `NewIssue.md` (or descriptively named file)
+4. Show the user the `gh` command to create the issue:
+   ```bash
+   gh issue create --title "<title>" --body-file NewIssue.md
+   ```
+5. Let the user run the command, which will create the issue and return the GitHub issue URL
+
+## User Story Format
+
+All issues must follow:
+
+```
+AS A <type of user>
+I WANT <some goal>
+SO THAT <some reason>
+```
+
+## Using GitHub CLI (gh)
+
+After the issue file is created, use the GitHub CLI to create the issue:
+
+### Checking Which Repository Will Be Used
+
+```bash
+# View current default repository
+gh repo set-default --view
+
+# Change default repository (interactive)
+gh repo set-default
+```
+
+
+### Basic Usage
+
+```bash
+# Uses default repository (aodn/backlog)
+gh issue create --title "Issue title" --body-file NewIssue.md
+
+# Explicitly specify repository
+gh issue create -R aodn/backlog --title "Issue title" --body-file NewIssue.md
+```
+
+### With Labels and Milestone
+
+```bash
+gh issue create --title "Add dark mode" \
+  --body-file NewIssue.md \
+  --label "type - development" \
+  --label "3 story points" \
+  --milestone "Top of the backlog"
+```
+
+### Common Labels
+
+- `type - development` - New feature or system
+- `type - operational` - Maintenance or operational work
+- `type - testing & release` - Manual testing and deployment
+- `Epic` - Too large for an iteration, needs breakdown
+- `Blocked` - Cannot be worked, has blocking dependencies
+- `1 story points`, `2 story points`, `3 story points`, etc. - Complexity estimates
+- `DataUplift` - the issue is related to Programe of Data Uplift 
+
+### Other Useful Commands
+
+```bash
+# List issues
+gh issue list
+
+# View an issue
+gh issue view <issue-number>
+
+# Add comment
+gh issue comment <issue-number> --body "Comment text"
+```

--- a/.github/skills/create-gh-issue/create-issue.md
+++ b/.github/skills/create-gh-issue/create-issue.md
@@ -1,93 +1,118 @@
 # Create Issue
 
-Create a GitHub issue for the project following the appropriate template.
+Create a GitHub issue for the AODN Pipeline Uplift Team project following the appropriate template.
 
 ## Instructions
 
-When the user describes an issue, determine the appropriate template and create a properly formatted issue file:
-
-### Template Selection
-
-create an common template under `.github/ISSUE_TEMPLATE/`
+When the user describes an issue, determine the type, format the title correctly, fill in the template, create the issue, and add it to the project board.
 
 ### Workflow
 
-1. Read the appropriate template from `.github/ISSUE_TEMPLATE/`
-2. Create the issue content following the template structure:
-   - Use proper user story format: AS A/I WANT/SO THAT
-   - Include acceptance criteria as checklist
-   - Add relevant sections (sub-tasks, related tickets, etc.)
-3. Write the content to `NewIssue.md` (or descriptively named file)
-4. Show the user the `gh` command to create the issue:
-   ```bash
-   gh issue create --title "<title>" --body-file NewIssue.md
-   ```
-5. Let the user run the command, which will create the issue and return the GitHub issue URL
+1. Determine the issue type (see **Issue Types** below)
+2. Format the title following the **Title Conventions**
+3. Read `.github/ISSUE_TEMPLATE/pipeline-general-template.md` and fill it in
+4. Write the content to `NewIssue.md`
+5. Create the issue and add it to the project board (see **Using GitHub CLI**)
 
-## User Story Format
+## Issue Types
 
-All issues must follow:
+| Type | Title prefix | When to use |
+|---|---|---|
+| User Story | `AS A … I WANT … SO THAT …` | A new capability from a user's perspective |
+| Feature / Enhancement | `✨` | A concrete deliverable or implementation task |
+| Task | `📋(TASK)` | An operational or process task |
+| Epic | plain title + `[epic]` tag | Too large for one iteration, needs breakdown |
+| Bug | plain title + `[bug]` tag | Something broken |
+| Technical Debt | plain title + `[technical debt]` tag | Clean-up or refactoring |
+
+## Title Conventions
+
+Titles follow this structure:
 
 ```
-AS A <type of user>
-I WANT <some goal>
-SO THAT <some reason>
+<prefix> <Short description> <[T-level tags]> <[type tag]>
 ```
+
+- **T-level tags** categorise the work area, e.g. `[T3 - ARDC Waves]`, `[T3 - Reef Network]`, `[T1 - IMOS, T2 - O&M - Continuous Improvement]`
+- **Type tags**: `[epic]`, `[bug]`, `[technical debt]`, `[DEVOPS, general backlog]`
+- Story points are set via **labels only** (not in the title)
+
+### Examples
+
+```
+AS A wave data user I WANT NRT buoy data gaps filled SO THAT my analysis is complete [T3 - ARDC Waves]
+✨WIS2.0 Prefect Flow
+📋(TASK) Apply mask into GSLA particle PNG generation
+Test implementation of WIS2.0 Wave Buoys Collection [epic]
+Scheduled diff check between CO files and NetCDF files [technical debt]
+```
+
+## Project Areas (Project field)
+
+Use the appropriate project area when creating the issue:
+
+| Area | Use for |
+|---|---|
+| `WIS2` | WIS 2.0 / wis2box work |
+| `Cloud Optimised` | Zarr, Parquet, CO library |
+| `Waves` | Wave buoy data, ARDC Waves |
+| `NRMN` | Reef Life Survey / NRMN data |
+| `BAU` | Business as usual, maintenance |
+| `Outreach` | Papers, workshops, demos |
+
+## Body Template
+
+Use `.github/ISSUE_TEMPLATE/pipeline-general-template.md` as the body. Fill every section:
+
+- **User Story** — AS A / I WANT / SO THAT (even for non-story issues, state the goal)
+- **Acceptance Criteria** — numbered list of verifiable outcomes
+- **Notes** — assumptions, constraints, background links
+- **Tasks** — checkbox list of sub-tasks; always include the DOD checklist link
+- **PRs** — leave as template placeholder; include PR review guidelines link
+- **Dependencies** — upstream issues or external blockers
 
 ## Using GitHub CLI (gh)
 
-After the issue file is created, use the GitHub CLI to create the issue:
-
-### Checking Which Repository Will Be Used
+### Step 1 — Create the issue
 
 ```bash
-# View current default repository
-gh repo set-default --view
-
-# Change default repository (interactive)
-gh repo set-default
-```
-
-
-### Basic Usage
-
-```bash
-# Uses default repository (aodn/backlog)
-gh issue create --title "Issue title" --body-file NewIssue.md
-
-# Explicitly specify repository
-gh issue create -R aodn/backlog --title "Issue title" --body-file NewIssue.md
-```
-
-### With Labels and Milestone
-
-```bash
-gh issue create --title "Add dark mode" \
+# Default repo is aodn/backlog; specify explicitly if needed
+gh issue create -R aodn/backlog \
+  --title "<formatted title>" \
   --body-file NewIssue.md \
   --label "type - development" \
-  --label "3 story points" \
-  --milestone "Top of the backlog"
+  --label "2 story points"
+```
+
+The command returns the new issue URL — copy it for Step 2.
+
+### Step 2 — Add to the AODN Pipeline Uplift Team project (#72)
+
+```bash
+gh project item-add 72 --owner aodn --url <issue-url>
 ```
 
 ### Common Labels
 
-- `type - development` - New feature or system
-- `type - operational` - Maintenance or operational work
-- `type - testing & release` - Manual testing and deployment
-- `Epic` - Too large for an iteration, needs breakdown
-- `Blocked` - Cannot be worked, has blocking dependencies
-- `1 story points`, `2 story points`, `3 story points`, etc. - Complexity estimates
-- `DataUplift` - the issue is related to Programe of Data Uplift 
+- `type - development` — New feature or system
+- `type - operational` — Maintenance or operational work
+- `type - testing & release` — Manual testing and deployment
+- `Epic` — Too large for an iteration, needs breakdown
+- `Blocked` — Cannot be worked on; has blocking dependencies
+- `1 story points`, `2 story points`, `3 story points`, `5 story points`, `8 story points` — Complexity estimate
 
 ### Other Useful Commands
 
 ```bash
-# List issues
-gh issue list
+# List open issues
+gh issue list -R aodn/backlog
 
 # View an issue
-gh issue view <issue-number>
+gh issue view <issue-number> -R aodn/backlog
 
-# Add comment
-gh issue comment <issue-number> --body "Comment text"
+# Add a comment
+gh issue comment <issue-number> -R aodn/backlog --body "Comment text"
+
+# List items currently in project #72
+gh project item-list 72 --owner aodn
 ```


### PR DESCRIPTION
This pull request adds new documentation to standardize and streamline the process of creating GitHub issues for the AODN Pipeline Uplift Team. It introduces a comprehensive workflow guide and a user story-based issue template, ensuring consistency and clarity in issue tracking.

**New issue creation workflow and templates:**

* Added a detailed guide (`.github/skills/create-gh-issue/create-issue.md`) describing how to create issues, including instructions on choosing issue types, formatting titles, filling in the body template, assigning labels, and adding issues to the project board using the GitHub CLI. The guide also standardizes title conventions, project area categorization, and label usage.
* Introduced a user story-driven issue template (`.github/ISSUE_TEMPLATE/pipeline-general-template.md`) for capturing user goals, acceptance criteria, notes, tasks (including AWS cleanup and Definition of Done checklist), PRs, dependencies, and demo requirements, promoting clarity and completeness in issue descriptions.